### PR TITLE
Update hubot-slack adapter to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "htmlparser": "^1.7.7",
     "hubot": ">= 2.6.0 < 3.0.0",
     "hubot-scripts": ">= 2.5.16 < 3.0.0",
-    "hubot-slack": "^2.0.4",
+    "hubot-slack": "^3.2.1",
     "node-whois": "latest",
     "optparse": "^1.0.3",
     "requestify": "^0.1.16",


### PR DESCRIPTION
This will make it so we can put hubot in private channels